### PR TITLE
Array.toString should return comma separated list

### DIFF
--- a/jsarray.c
+++ b/jsarray.c
@@ -395,6 +395,7 @@ static void Ap_toString(js_State *J)
 {
 	unsigned int top = js_gettop(J);
 	js_pop(J, top - 1);
+        js_pushstring (J, ",");
 	Ap_join(J);
 }
 


### PR DESCRIPTION
The call to Array.join in Array.toString should provide a comma as the separator string
